### PR TITLE
Rename Charité labels column

### DIFF
--- a/src/data_download/charite_unpack.py
+++ b/src/data_download/charite_unpack.py
@@ -51,8 +51,8 @@ def unpack_charite(path):
         header_io.close()
         # Drop last element
         ss = ss.iloc[:-1]
-        ss.columns = ['sleep_phase']
-        ss['subject'] = pc
+        ss.columns = ["label"]
+        ss["subject"] = pc
         # Check that times are not too far off
         lights_off = start_recordings[i]
         lights_on = end_recordings[i]
@@ -75,7 +75,7 @@ def unpack_charite(path):
         # Add timestamp column to the ss
         psg_start = timedelta(hours=float(header['psg_start'].to_numpy()[0])) + start_date
         psg_stop = timedelta(hours=float(header['psg_stop'].to_numpy()[0])) + start_date
-        idx = pd.date_range(start=psg_start, end=psg_stop, periods=ss['sleep_phase'].size)
+        idx = pd.date_range(start=psg_start, end=psg_stop, periods=ss["label"].size)
         # Check if periods are roughly 30s long
         if (idx[1] - idx[0]).total_seconds() < 29 or (idx[1] - idx[0]).total_seconds() > 31:
             print(f'{pc} has sleep staging periods that are not 30s')


### PR DESCRIPTION
## Summary
- rename the Charité sleep stage column to `label` during dataset unpacking so downstream preprocessing expects the same schema as other datasets
- simplify the label quality check now that the Charité labels match the standard column name

## Testing
- uv run pytest

------
https://chatgpt.com/codex/tasks/task_b_68d5516cb5a8832ebbf9f8bef4538c25