### PR TITLE
Validate Charite sleep labels and report kept subjects

### DIFF
--- a/src/data_download/charite_unpack.py
+++ b/src/data_download/charite_unpack.py
@@ -82,6 +82,13 @@ def unpack_charite(path):
             sleep.append(None)
             continue
         ss['timestamp'] = idx
+        # Validate that sleep labels are restricted to stages 0-5
+        labels_numeric = pd.to_numeric(ss['label'], errors='coerce')
+        if labels_numeric.isna().any() or not labels_numeric.isin([0, 1, 2, 3, 4, 5]).all():
+            print(f'{pc} has invalid sleep stage labels; discarding subject.')
+            sleep.append(None)
+            continue
+        ss['label'] = labels_numeric.astype(int)
         if header['error_code'].to_numpy()[0] == 0:
             sleep.append(ss)
         else:

--- a/src/data_download/data_unpack.py
+++ b/src/data_download/data_unpack.py
@@ -85,7 +85,8 @@ def unpack_labelled_dataset(
     elif dataset_name == "newcastle":
         labels_data, motion_data = unpack_newcastle(dataset_path, label_dict)
     elif dataset_name == "charite":
-        motion_data, _, labels_data, _ = unpack_charite(dataset_path)
+        motion_data, _, labels_data, patient_codes = unpack_charite(dataset_path)
+        print(f"Kept {len(patient_codes)} subjects after unpacking Charité dataset: {patient_codes}")
     else:
         raise ValueError(f"Unknown dataset name: {dataset_name}")
 


### PR DESCRIPTION
## Summary
- validate Charité sleep stage labels to ensure they stay within stages 0-5 and drop invalid subjects
- display which subjects remain after unpacking the Charité dataset

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68d64f3ac97c832e829523f5eacdce4f