### PR TITLE
Simplify heart-rate ingestion for LSTM HR pipeline

### DIFF
--- a/conf/classifier/dataset/charitehr.yaml
+++ b/conf/classifier/dataset/charitehr.yaml
@@ -1,0 +1,16 @@
+name: charitehr
+unpacked_path: charite/Somno
+url: https://polybox.ethz.ch/index.php/s/2tjtpXi2rKRy6om/download
+archive: tar
+sampling_rate: 128
+has_labels: true
+has_heart_rate: true
+hr_noise_std: 0.0
+labels:
+  0: 0
+  1: 1
+  2: 2
+  3: 3
+  4: 4
+  5: 5
+sampling_period_ms: ${eval:'1000/${sampling_rate}'}

--- a/conf/classifier/network/lstm_hr.yaml
+++ b/conf/classifier/network/lstm_hr.yaml
@@ -1,0 +1,8 @@
+name: lstm_hr_classifier
+prev_minutes: 5
+post_minutes: 0
+clip_gradients: true
+pad_input: true
+is_lstm: true
+hr_input_size: 1
+hr_projection_dim: 16

--- a/src/data_download/data_unpack.py
+++ b/src/data_download/data_unpack.py
@@ -76,6 +76,7 @@ def unpack_labelled_dataset(
     """
 
 
+    hr_data = None
     if dataset_name == "applewatch":
         labels_data, motion_data = unpack_applewatch(dataset_path)
 
@@ -87,21 +88,26 @@ def unpack_labelled_dataset(
     elif dataset_name == "charite":
         motion_data, _, labels_data, patient_codes = unpack_charite(dataset_path)
         print(f"Kept {len(patient_codes)} subjects after unpacking Charité dataset: {patient_codes}")
+    elif dataset_name == "charitehr":
+        motion_data, hr_data, labels_data, patient_codes = unpack_charite(dataset_path)
+        print(f"Kept {len(patient_codes)} subjects after unpacking Charité HR dataset: {patient_codes}")
     else:
         raise ValueError(f"Unknown dataset name: {dataset_name}")
 
-    make_1_to_1_corresp(labels_data, motion_data)
+    make_1_to_1_corresp(labels_data, motion_data, hr_data)
     # Remove subject column
     subject_ids = []
     for i in range(len(motion_data)):
         subject_id = motion_data[i]["subject"].iloc[0]
-        if dataset_name == "charite" or dataset_name == "chartiehr":
+        if dataset_name == "charite" or dataset_name == "charitehr":
             # Convert the id to int
             subject_id = int(subject_id.replace("SL", ""))
         subject_ids.append(subject_id)
         motion_data[i].drop(columns=["subject"], inplace=True)
         labels_data[i].drop(columns=["subject"], inplace=True)
-    return motion_data, labels_data, subject_ids
+        if hr_data is not None:
+            hr_data[i].drop(columns=["subject"], inplace=True)
+    return motion_data, labels_data, subject_ids, hr_data
 
 
 def unpack_newcastle(dataset_path, label_dict):
@@ -420,7 +426,7 @@ def unpack_applewatch(dataset_path):
     return labels_data, motion_data
 
 
-def make_1_to_1_corresp(labels_data, motion_data):
+def make_1_to_1_corresp(labels_data, motion_data, hr_data=None):
     """
     Ensures that the labels and motion data are in the same order and that there is a 1 to 1 correspondence between
     them.
@@ -434,8 +440,12 @@ def make_1_to_1_corresp(labels_data, motion_data):
     # Sort motion data and labels by ID
     motion_data.sort(key=lambda x: x["subject"].iloc[0])
     labels_data.sort(key=lambda x: x["subject"].iloc[0])
+    if hr_data is not None:
+        hr_data.sort(key=lambda x: x["subject"].iloc[0])
     # Ensure that motion data and labels have the same length and that the IDs match
     assert len(motion_data) == len(labels_data)
     for i in range(len(motion_data)):
         assert motion_data[i]["subject"].iloc[0] == labels_data[i]["subject"].iloc[0]
+        if hr_data is not None:
+            assert motion_data[i]["subject"].iloc[0] == hr_data[i]["subject"].iloc[0]
         print(motion_data[i]["subject"].iloc[0])

--- a/src/data_preprocessing/data_preprocessing.py
+++ b/src/data_preprocessing/data_preprocessing.py
@@ -20,6 +20,7 @@ def make_dataset(
     dataset_sample_rate = dataset_cfg.sampling_rate
     cache_path = paths_cfg.processed_data
     label_dict = dataset_cfg.labels if dataset_cfg.has_labels else None
+    has_heart_rate = getattr(dataset_cfg, "has_heart_rate", False)
 
     if dataset_path is None:
         dataset_path = os.path.join(paths_cfg.datasets, dataset_cfg.unpacked_path)
@@ -30,6 +31,7 @@ def make_dataset(
             loaded_from_cache,
             motion_data_list,
             labels_list,
+            hr_data_list,
             subject_ids,
         ) = load_preprocessed_dataset(
             dataset_name,
@@ -39,6 +41,7 @@ def make_dataset(
             win_len_s,
             normalize_data,
             cache_path,
+            load_hr_data=has_heart_rate,
         )
 
     if loaded_from_cache:
@@ -47,13 +50,15 @@ def make_dataset(
         print("Dataset not loaded from cache")
 
     if loaded_from_cache and dataset_cfg.has_labels:
+        if has_heart_rate:
+            return motion_data_list, labels_list, hr_data_list, subject_ids
         return motion_data_list, labels_list, subject_ids
     elif loaded_from_cache and not dataset_cfg.has_labels:
         return motion_data_list, subject_ids
 
     if dataset_cfg.has_labels:
         # Load raw dataset
-        motion_data_list, labels_list, subject_ids = unpack_labelled_dataset(
+        motion_data_list, labels_list, subject_ids, hr_data_list = unpack_labelled_dataset(
             dataset_name,
             dataset_path,
             label_dict,
@@ -62,6 +67,10 @@ def make_dataset(
         # Load raw dataset
         motion_data_list, subject_ids = unpack_unlabelled_dataset(
             dataset_name, dataset_path)
+        hr_data_list = None
+
+    if has_heart_rate and hr_data_list is None:
+        hr_data_list = [None for _ in range(len(motion_data_list))]
 
     for i in range(len(motion_data_list)):
         # Actipy requires that the DateTimeIndex has name 'time'
@@ -86,6 +95,13 @@ def make_dataset(
                                                  win_len_samples=win_len_samples)
         motion_data_list[i] = motion_data_sample
 
+        if has_heart_rate and hr_data_list[i] is not None:
+            hr_data_list[i] = process_heart_rate_data(
+                hr_data_list[i],
+                labels_list[i] if dataset_cfg.has_labels else None,
+                motion_data_sample.index,
+            )
+
     # Save preprocessed dataset to disk
     save_preprocessed_dataset(
         dataset_name,
@@ -97,9 +113,12 @@ def make_dataset(
         win_len_s,
         normalize_data,
         cache_path,
+        hr_data_list=hr_data_list if has_heart_rate else None,
     )
 
     if dataset_cfg.has_labels:
+        if has_heart_rate:
+            return motion_data_list, labels_list, hr_data_list, subject_ids
         return motion_data_list, labels_list, subject_ids
     else:
         return motion_data_list, subject_ids
@@ -141,6 +160,30 @@ def process_labelled_data(labels_sample, motion_data_sample, win_len_samples):
 
 
 
+def process_heart_rate_data(hr_data_sample, labels_sample, motion_index):
+    """Align heart rate samples with processed motion and labels."""
+    if hr_data_sample.empty:
+        return hr_data_sample
+
+    hr_processed = hr_data_sample.copy()
+    if labels_sample is not None and not labels_sample.empty:
+        min_label_time = labels_sample.index.min()
+        max_label_time = labels_sample.index.max()
+        hr_processed = hr_processed[(hr_processed.index >= min_label_time) & (hr_processed.index <= max_label_time)]
+
+    if len(motion_index) > 0:
+        start_time = motion_index[0]
+        end_time = motion_index[-1]
+        hr_processed = hr_processed[(hr_processed.index >= start_time) & (hr_processed.index <= end_time)]
+
+    if "bpm" in hr_processed.columns:
+        hr_processed["bpm"] = hr_processed["bpm"].astype(np.float32)
+
+    hr_processed = hr_processed[~hr_processed.index.duplicated(keep="first")]
+    return hr_processed
+
+
+
 def is_good_quality(window, sampling_rate, window_sec, window_tol=0.01):
     """Window quality check"""
     window_len = int(window_sec * sampling_rate)
@@ -171,10 +214,18 @@ def has_good_label(window, labels):
     return True
 
 def load_preprocessed_dataset(
-        dataset_name, has_labels, low_pass_filter_freq, model_sampling_rate, win_len_s, normalize_data, cache_path
+        dataset_name,
+        has_labels,
+        low_pass_filter_freq,
+        model_sampling_rate,
+        win_len_s,
+        normalize_data,
+        cache_path,
+        load_hr_data=False,
 ):
     motion_data_list = []
     labels_list = []
+    hr_data_list = [] if load_hr_data else None
     loaded_from_cache = False
     for file in os.scandir(cache_path):
         if file.name.endswith("_preprocessed.csv"):
@@ -203,7 +254,8 @@ def load_preprocessed_dataset(
                 and normalize_data_pre == normalize_data
             ):
                 loaded_from_cache = True
-                if file.name.split("_")[1] == "motion":
+                file_type = file.name.split("_")[1]
+                if file_type == "motion":
                     data = pd.read_csv(
                         file.path,
                         parse_dates=["timestamp"],
@@ -213,7 +265,7 @@ def load_preprocessed_dataset(
                     data.set_index("timestamp", inplace=True)
                     motion_data_list.append(data)
 
-                if file.name.split("_")[1] == "labels":
+                if file_type == "labels":
                     data = pd.read_csv(
                         file.path,
                         parse_dates=["timestamp"],
@@ -224,18 +276,33 @@ def load_preprocessed_dataset(
                     data["subject"] = loaded_id
                     data.set_index("timestamp", inplace=True)
                     labels_list.append(data)
+                if load_hr_data and file_type == "hr":
+                    data = pd.read_csv(
+                        file.path,
+                        parse_dates=["timestamp"],
+                        dtype={"bpm": np.float32},
+                    )
+                    data["subject"] = loaded_id
+                    data.set_index("timestamp", inplace=True)
+                    hr_data_list.append(data)
     # Sort data according to subject id
     try:
         subject_ids = [motion_data_list[i]["subject"].iloc[0] for i in range(len(motion_data_list))]
         if has_labels:
-            make_1_to_1_corresp(motion_data_list, labels_list)
+            make_1_to_1_corresp(labels_list, motion_data_list, hr_data_list if load_hr_data else None)
         for i in range(len(motion_data_list)):
             motion_data_list[i] = motion_data_list[i].drop(columns=["subject"])
             if has_labels:
                 labels_list[i] = labels_list[i].drop(columns=["subject"])
+            if load_hr_data and i < len(hr_data_list) and hr_data_list[i] is not None:
+                hr_data_list[i] = hr_data_list[i].drop(columns=["subject"])
     except:
-        return False, None, None, None
-    return loaded_from_cache, motion_data_list, labels_list, subject_ids
+        return False, None, None, None, None
+    if load_hr_data and hr_data_list is not None and len(hr_data_list) < len(motion_data_list):
+        hr_data_list.extend([None for _ in range(len(motion_data_list) - len(hr_data_list))])
+    if not load_hr_data:
+        hr_data_list = None
+    return loaded_from_cache, motion_data_list, labels_list, hr_data_list, subject_ids
 
 def save_preprocessed_dataset(
         dataset_name,
@@ -247,6 +314,7 @@ def save_preprocessed_dataset(
         win_len_s,
         normalize,
         cache_path,
+        hr_data_list=None,
 ):
     for i in range(len(motion_data_list)):
         id_i = subject_ids[i]
@@ -273,6 +341,17 @@ def save_preprocessed_dataset(
                 index=False,
             )
             labels_list[i] = labels_list[i].drop(columns=["timestamp"])
+        if hr_data_list is not None and len(hr_data_list) > 0 and hr_data_list[i] is not None:
+            hr_data_list[i]["timestamp"] = hr_data_list[i].index
+            hr_data_list[i].to_csv(
+                os.path.join(
+                    cache_path,
+                    f"{dataset_name}_hr_samplingrate_{str(model_sampling_rate)}_lowpass_{str(low_pass_filter_freq)}"
+                    f"_id_{str(id_i)}_wls_{str(win_len_s)}_norm_{str(int(normalize))}_preprocessed.csv",
+                ),
+                index=False,
+            )
+            hr_data_list[i] = hr_data_list[i].drop(columns=["timestamp"])
 
 def drop_rows_without_label(data_df: pd.DataFrame, label_df: pd.DataFrame):
     """

--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -1,6 +1,6 @@
 from .resnet import Resnet
 from .rnn import RNNModel
-from .lstm import LSTMModel
+from .lstm import LSTMModel, LSTMWithHeartRateModel
 from .resnet1d import ResNet1D
 from .simclr import SimCLR
 from .ntxent_loss import NTXentLossNew

--- a/src/models/lstm.py
+++ b/src/models/lstm.py
@@ -132,3 +132,53 @@ class LSTMModel(nn.Module):
         cell = torch.zeros(self.d_param * self.num_layers, batch_size, self.h_cell)
         cell = cell.to(self.device)
         return cell
+
+
+class LSTMWithHeartRateModel(LSTMModel):
+    def __init__(
+        self,
+        feature_input_size,
+        hr_input_size,
+        hr_projection_dim,
+        hidden_dim,
+        num_classes,
+        device,
+        num_channels=3,
+        feature_extractor=None,
+        use_all_hidden=False,
+        sequence_length=1,
+        bidireactional=False,
+        num_layers=1,
+        dropout=0.0,
+        proj_size=0,
+    ):
+        if hr_input_size <= 0:
+            raise ValueError("hr_input_size must be positive for LSTMWithHeartRateModel")
+        total_input_size = feature_input_size + hr_projection_dim
+        super().__init__(
+            input_size=total_input_size,
+            hidden_dim=hidden_dim,
+            num_classes=num_classes,
+            device=device,
+            num_channels=num_channels,
+            feature_extractor=feature_extractor,
+            use_all_hidden=use_all_hidden,
+            sequence_length=sequence_length,
+            bidireactional=bidireactional,
+            num_layers=num_layers,
+            dropout=dropout,
+            proj_size=proj_size,
+        )
+        self.feature_input_size = feature_input_size
+        self.hr_input_size = hr_input_size
+        self.hr_projection = nn.Sequential(
+            nn.Linear(hr_input_size, hr_projection_dim),
+            nn.ReLU(),
+        )
+
+    def forward(self, x, seq_lengths):
+        feature_part = x[:, :, : self.feature_input_size]
+        hr_part = x[:, :, self.feature_input_size : self.feature_input_size + self.hr_input_size]
+        hr_emb = self.hr_projection(hr_part)
+        combined = torch.cat([feature_part, hr_emb], dim=2)
+        return super().forward(combined, seq_lengths)

--- a/src/torch_datasets/acc_dataset.py
+++ b/src/torch_datasets/acc_dataset.py
@@ -20,6 +20,8 @@ class AccDataset(Dataset):
         label_col="label",
         label_transform=None,
         channels_first=True,
+        heart_rate_df=None,
+        heart_rate_col="bpm",
     ):
         """
         Dataset for accelerometer data contiguously sampled at a fixed frequency.
@@ -43,6 +45,15 @@ class AccDataset(Dataset):
         self.label_col = label_col
         self.label_transform = label_transform
         self.channels_first = channels_first
+        self.heart_rate_series = None
+        if heart_rate_df is not None and not heart_rate_df.empty:
+            if not is_datetime64_dtype(heart_rate_df.index):
+                raise ValueError("Heart rate dataframe index must be datetime64")
+            if heart_rate_col not in heart_rate_df.columns:
+                raise ValueError(f"Heart rate dataframe must contain column '{heart_rate_col}'")
+            heart_rate_series = heart_rate_df[heart_rate_col].astype(np.float32)
+            heart_rate_series = heart_rate_series[~heart_rate_series.index.duplicated(keep="first")]
+            self.heart_rate_series = heart_rate_series.sort_index()
 
         self.length = math.floor(motion_df.shape[0] / samples_per_window)
     def __len__(self):
@@ -62,6 +73,21 @@ class AccDataset(Dataset):
         if self.channels_first:
             sample = sample.T
         label = apply_label_transform(label, self.label_transform)
+
+        hr_tensor = None
+        if self.heart_rate_series is not None and len(self.heart_rate_series) > 0:
+            hr_index = self.heart_rate_series.index.get_indexer([data_timestamp], method="nearest")
+            if hr_index.size > 0 and hr_index[0] != -1:
+                hr_value = float(self.heart_rate_series.iloc[hr_index[0]])
+                hr_tensor = torch.tensor(hr_value, dtype=torch.float32)
+
+        if hr_tensor is not None:
+            return (
+                torch.from_numpy(sample),
+                torch.tensor(label, dtype=torch.long),
+                hr_tensor,
+            )
+
         return torch.from_numpy(sample), torch.tensor(label, dtype=torch.long)
 
 def apply_label_transform(label, label_transform):

--- a/src/torch_datasets/precomputed_features_dataset.py
+++ b/src/torch_datasets/precomputed_features_dataset.py
@@ -12,7 +12,13 @@ from pandas.api.types import is_datetime64_dtype
 
 class PrecomputedFeaturesDataset(Dataset):
     def __init__(
-        self, feature_extractor, feature_extractor_output_length, acc_dataset, device
+        self,
+        feature_extractor,
+        feature_extractor_output_length,
+        acc_dataset,
+        device,
+        hr_noise_std=0.0,
+        noise_seed=None,
     ):
         """
 
@@ -24,12 +30,22 @@ class PrecomputedFeaturesDataset(Dataset):
 
         """
         self.length = len(acc_dataset)
+        self.hr_noise_std = float(hr_noise_std) if hr_noise_std is not None else 0.0
+        self.noise_seed = noise_seed
 
         dataloader = DataLoader(acc_dataset, batch_size=len(acc_dataset), shuffle=False, drop_last=False)
         i = 0
         feature_extractor.to(device)
 
-        for data, label in (progress := tqdm(dataloader)):
+        hr_features_array = None
+        for batch in (progress := tqdm(dataloader)):
+            if isinstance(batch, (list, tuple)) and len(batch) == 3:
+                data, label, hr_tensor = batch
+                hr_features_array = hr_tensor.numpy(force=True).astype(np.float32)
+                if hr_features_array.ndim == 1:
+                    hr_features_array = hr_features_array[:, None]
+            else:
+                data, label = batch
             feature_extractor.eval()
             with torch.no_grad():
                 data = data.to(device)
@@ -40,8 +56,16 @@ class PrecomputedFeaturesDataset(Dataset):
                 i = i + 1
                 features_data = features.numpy(force=True)
                 labels_data = label.numpy(force=True)
+        if hr_features_array is not None:
+            if self.hr_noise_std > 0:
+                rng = np.random.default_rng(self.noise_seed)
+                hr_noise = rng.normal(0.0, self.hr_noise_std, size=hr_features_array.shape).astype(np.float32)
+                hr_features_array = hr_features_array + hr_noise
+            features_data = np.concatenate([features_data, hr_features_array], axis=1)
         self.features_data = features_data
         self.labels_data = labels_data
+        self.hr_features = hr_features_array
+        self.base_feature_dim = feature_extractor_output_length
 
     def __len__(self):
         return self.length

--- a/src/train_classifier/classifier_models.py
+++ b/src/train_classifier/classifier_models.py
@@ -1,7 +1,7 @@
 import os
 import re
 import torch
-from src.models import Resnet, RNNModel, LSTMModel, SimCLR
+from src.models import Resnet, RNNModel, LSTMModel, LSTMWithHeartRateModel, SimCLR
 from src.train_ssl import get_backbone_network
 from torch import nn
 import zipfile
@@ -62,6 +62,7 @@ def get_full_classification_model(
             device=device,
             dropout=dropout,
             clip_gradients=clip_gradients,
+            classifier_cfg=classifier_cfg,
         )
     else:
         my_model = get_classification_model(
@@ -74,6 +75,7 @@ def get_full_classification_model(
             device=device,
             dropout=dropout,
             clip_gradients=clip_gradients,
+            classifier_cfg=classifier_cfg,
         )
 
     # print(my_model)
@@ -106,6 +108,7 @@ def get_classification_model(
     feature_extractor=None,
     dropout=0,
     clip_gradients=False,
+    classifier_cfg=None,
 ):
     """
 
@@ -158,6 +161,25 @@ def get_classification_model(
         # LSTM Classifier
         model = LSTMModel(
             input_size=feature_ext_output_size,
+            hidden_dim=128,
+            num_classes=num_classes,
+            device=device,
+            feature_extractor=feature_extractor,
+            use_all_hidden=False,
+            bidireactional=False,
+            sequence_length=prev_window + post_window + 1,
+            dropout=dropout,
+            num_layers=2,
+        )
+    elif name == 'lstm_hr_classifier':
+        hr_input_size = getattr(classifier_cfg, "hr_input_size", 0) if classifier_cfg is not None else 0
+        if hr_input_size <= 0:
+            raise ValueError("hr_input_size must be positive for lstm_hr_classifier")
+        hr_projection_dim = getattr(classifier_cfg, "hr_projection_dim", hr_input_size) if classifier_cfg is not None else hr_input_size
+        model = LSTMWithHeartRateModel(
+            feature_input_size=feature_ext_output_size,
+            hr_input_size=hr_input_size,
+            hr_projection_dim=hr_projection_dim,
             hidden_dim=128,
             num_classes=num_classes,
             device=device,

--- a/src/train_classifier/run_classification.py
+++ b/src/train_classifier/run_classification.py
@@ -76,6 +76,7 @@ def run_classification(
     classifier_is_lstm = classifier_cfg.is_lstm
     torch.manual_seed(seed)
     dataset_name = dataset_cfg.name
+    hr_input_size = getattr(classifier_cfg, "hr_input_size", 0)
     if not freeze_foundational_model and precompute_features:
         raise ValueError(
             "Cannot precompute features if foundational model is not frozen."
@@ -102,6 +103,14 @@ def run_classification(
         return_filename=True,
         batch_norm_after_feature_extractor=batch_norm_after_feature_extractor,
     )
+    dataset_has_hr = getattr(dataset_cfg, "has_heart_rate", False)
+    hr_noise_std = getattr(dataset_cfg, "hr_noise_std", 0.0) if hr_input_size > 0 else 0.0
+    if hr_input_size > 0 and not dataset_has_hr:
+        raise ValueError(
+            "Classifier configuration expects heart rate input but dataset does not provide it."
+        )
+    if hr_input_size <= 0:
+        hr_noise_std = 0.0
     classifier_name = classifier_cfg.name
     pad_input = classifier_cfg.pad_input
     prev_window = math.ceil(classifier_cfg.prev_minutes * 60.0 / input_len_sec)
@@ -137,6 +146,9 @@ def run_classification(
         'Pad LSTM input with zeros': pad_input,
         'Burn in epochs': burn_in_epochs,
         'Feature extractor filename': feature_extractor_filename,
+        'hr_input_size': hr_input_size,
+        'hr_noise_std': hr_noise_std,
+        'dataset_has_hr': dataset_has_hr,
     })
     (
         my_model,
@@ -166,12 +178,8 @@ def run_classification(
     # Load data: First preprocess the data and get list of per-subject dataframes, then
     dataset_list = []
     subject_ids = []
-    for name in dataset_name:
-        (
-            dataset_list_name,
-            labels_list_name,
-            subject_ids_name,
-        ) = make_dataset(
+    for _ in dataset_name:
+        result = make_dataset(
             dataset_cfg=dataset_cfg,
             paths_cfg=paths_cfg,
             target_sampling_rate=sampling_rate,
@@ -180,18 +188,28 @@ def run_classification(
             win_len_s=input_len_sec,
             normalize_data=normalize_data,
         )
-        dataset_list_name = [
-            AccDataset(
-                motion_df=dataset_list_name[k],
-                label_df=labels_list_name[k],
-                samples_per_window=sampling_rate * input_len_sec,
-                label_transform=train_label_transform_dict,
-            )
-            for k in range(len(dataset_list_name))
-        ]
+        if dataset_has_hr:
+            motion_frames, label_frames, hr_frames, subject_ids_name = result
+        else:
+            motion_frames, label_frames, subject_ids_name = result
+            hr_frames = [None for _ in range(len(motion_frames))]
 
-        dataset_list.extend(dataset_list_name)
+        for motion_df, label_df, hr_df in zip(motion_frames, label_frames, hr_frames):
+            dataset_list.append(
+                AccDataset(
+                    motion_df=motion_df,
+                    label_df=label_df,
+                    samples_per_window=sampling_rate * input_len_sec,
+                    label_transform=train_label_transform_dict,
+                    heart_rate_df=hr_df if dataset_has_hr else None,
+                )
+            )
         subject_ids.extend(subject_ids_name)
+
+    if hr_input_size > 0 and not precompute_features:
+        raise ValueError(
+            "Heart rate augmented LSTM currently requires precomputed features."
+        )
 
     if precompute_features:
         dataset_list = [
@@ -200,6 +218,8 @@ def run_classification(
                 feature_extractor_output_length=feature_extractor_output_len,
                 acc_dataset=dataset_list[i],
                 device=device,
+                hr_noise_std=hr_noise_std,
+                noise_seed=seed + i if hr_noise_std > 0 else None,
             )
             for i in range(len(dataset_list))
         ]


### PR DESCRIPTION
## Summary
- extend `AccDataset` to return the nearest heart-rate sample per motion window and propagate it through feature caching
- simplify heart-rate feature handling by letting `PrecomputedFeaturesDataset` append scalar HR values with optional noise injection
- update classification pipeline and configs to assume a single HR input value for the heart-rate-aware LSTM

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_b_68e11af05d5c832e90d8cb64a53314d9